### PR TITLE
Fix/heroku server

### DIFF
--- a/src/main/java/nl/ordina/jobcrawler/SearchRequest.java
+++ b/src/main/java/nl/ordina/jobcrawler/SearchRequest.java
@@ -1,14 +1,18 @@
 package nl.ordina.jobcrawler;
 
 import lombok.AllArgsConstructor;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Value  // makes getters and makes attributes private final
+// on the server jackson gives an error that this class does not have a default constructor, which cannot exist with a final variable
+//@Value  // makes getters and makes attributes private final
+@NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public class SearchRequest {
 
-    String location;
-    String distance;
-    String keywords;
+    private String location;
+    private String distance;
+    private String keywords;
 
 }

--- a/src/main/java/nl/ordina/jobcrawler/controller/JobcrawlerController.java
+++ b/src/main/java/nl/ordina/jobcrawler/controller/JobcrawlerController.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 
 
-@CrossOrigin(origins = "http://localhost:4200")
+@CrossOrigin
 @RestController
 public class JobcrawlerController {
 


### PR DESCRIPTION
The SearchRequest's variables were changed to non-final, because when deployed an error with jackson no default constructor:
chRequest]; nested exception is com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `nl.ordina.jobcrawler.SearchRequest
DefinitionException: Cannot construct instance of `nl.ordina.jobcrawler.SearchRequest` (no Creators, like default construct, exist):