### PR TITLE
Fix/yacht url

### DIFF
--- a/src/main/java/nl/ordina/jobcrawler/model/Skill.java
+++ b/src/main/java/nl/ordina/jobcrawler/model/Skill.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.UUID;
 
 @Entity
-@ToString
 @Getter
 @Setter
 @RequiredArgsConstructor
@@ -23,10 +22,11 @@ public class Skill {
     @Id
     private UUID id;
 
-    @Column(nullable = false, unique = true)
+    // Skill may not be null, must be unique. Define column as text as varchar is limited to 255 characters. Skill can be a long sentence. Prevent hibernate DataException.
+    @Column(nullable = false, unique = false, columnDefinition = "TEXT") // Unique set to false for MVP. Set to true in combination with entitymanager if skill column is still needed at some point.
     private String name;
 
-    @ManyToMany(mappedBy = "skills")
+    @ManyToMany(mappedBy = "skills", fetch = FetchType.EAGER)
     @JsonIgnoreProperties("skills")
     Set<Vacancy> vacancies = new HashSet<>();
 

--- a/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyScraper.java
+++ b/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyScraper.java
@@ -21,7 +21,7 @@ Most of the code in this class is based on the available Arabot code. Some chang
 @Component
 public class YachtVacancyScraper extends VacancyScraper {
 
-    private static final String SEARCH_URL = "https://www.yacht.nl/vacatures?soortdienstverband=Detachering&zoekterm=java";
+    private static final String SEARCH_URL = "https://www.yacht.nl/vacatures?vakgebiedProf=IT";
     private static final String BROKER = "Yacht";
 
     @Autowired

--- a/src/main/java/nl/ordina/jobcrawler/service/VacancyService.java
+++ b/src/main/java/nl/ordina/jobcrawler/service/VacancyService.java
@@ -26,10 +26,18 @@ public class VacancyService {
     //******** Adding ********//
     // Adding vacancy and accompanying skills and relations to the database //
     public Vacancy add(Vacancy vacancy) {
+        /**
+         * The function below which is commented out, is used to prevent duplicate skills in the skills table.
+         * For some reason it throws a hibernate exception; detached entity passed to persist
+         * javax.persistence.PersistenceException
+         * We can solve this using an EntityManager. Implementing this will take some time while after the mvp we might put the entire vacancy body into a single column. By commenting out the lines below we allow duplicates.
+         * The unique parameter in Skill.java is set to false. Someone using the application won't notice the difference.
+         */
+        
         //replacing the skills with existing skills from the database if present
-        Set<Skill> existingSkills = skillService.linkToExistingSkills(vacancy.getSkills());
-        existingSkills.forEach(skill -> skill.addVacancy(vacancy)); // add the vacancy to the skill
-        vacancy.setSkills(existingSkills); // add the skills to the vacancy
+//        Set<Skill> existingSkills = skillService.linkToExistingSkills(vacancy.getSkills());
+//        existingSkills.forEach(skill -> skill.addVacancy(vacancy)); // add the vacancy to the skill
+//        vacancy.setSkills(existingSkills); // add the skills to the vacancy
 
 
         vacancy.checkURL(); //checking the url, if it is malformed it will throw a VacancyURLMalformedException

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,5 +17,3 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 server.error.include-stacktrace=on_trace_param
-
-server.port=8084


### PR DESCRIPTION
- Change yacht url to get all IT Yacht vacancies.
- Changed the name columnDefinition in skill.java from varchar(255) to text as some skills are somehow very detailed and contains more than 255 chars causing hibernate DataException.
- Allow duplicate skills. We can fix this using an EntityManager. That will take time and unsure if that's needed.