### PR TITLE
Fix/yacht site

### DIFF
--- a/src/main/java/nl/ordina/jobcrawler/model/VacancyURLs.java
+++ b/src/main/java/nl/ordina/jobcrawler/model/VacancyURLs.java
@@ -11,7 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class VacancyURLs {
     private String url;
+    private String title;
     private String hours;
+    private String location;
+    private String vacancyNumber;
+    private String postingDate;
 
     public VacancyURLs(String url) {
         this.url = url;

--- a/src/main/java/nl/ordina/jobcrawler/scrapers/VacancyScraper.java
+++ b/src/main/java/nl/ordina/jobcrawler/scrapers/VacancyScraper.java
@@ -46,6 +46,10 @@ abstract class VacancyScraper {
                         .vacancyURL(vacancyURL.getUrl())
                         .broker(BROKER)
                         .hours(vacancyURL.getHours())
+                        .location(vacancyURL.getLocation())
+                        .postingDate(vacancyURL.getPostingDate())
+                        .vacancyNumber(vacancyURL.getVacancyNumber())
+                        .title(vacancyURL.getTitle())
                         .skills(new HashSet<>())
                         .build();
                 setVacancyTitle(doc, vacancy);

--- a/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyResponse.java
+++ b/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyResponse.java
@@ -1,0 +1,28 @@
+package nl.ordina.jobcrawler.scrapers;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class YachtVacancyResponse {
+
+    private Integer currentPage;
+    private Integer pages;
+    private ArrayList<Map<String, Object>> vacancies;
+
+    private void unpackNested(Map<String, Object> result) {
+        this.currentPage = (Integer) result.get("currentPage");
+        this.pages = (Integer) result.get("pages");
+        this.vacancies = (ArrayList<Map<String, Object>>) result.get("vacancies");
+    }
+}

--- a/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyScraper.java
+++ b/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyScraper.java
@@ -91,6 +91,7 @@ public class YachtVacancyScraper extends VacancyScraper {
         return response.getBody();
     }
 
+    // The getTotalNumberOfPages method is not used by this scraper. As the YachtVacancyScraper extends VacancyScraper it is required to provide an implementation for this method.
     @Override
     protected int getTotalNumberOfPages(Document doc) {
         return 1;

--- a/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyScraper.java
+++ b/src/main/java/nl/ordina/jobcrawler/scrapers/YachtVacancyScraper.java
@@ -1,7 +1,6 @@
 package nl.ordina.jobcrawler.scrapers;
 
 import lombok.extern.slf4j.Slf4j;
-import nl.ordina.jobcrawler.controller.exception.VacancyURLMalformedException;
 import nl.ordina.jobcrawler.model.Vacancy;
 import nl.ordina.jobcrawler.model.VacancyURLs;
 import nl.ordina.jobcrawler.service.ConnectionDocumentService;
@@ -15,7 +14,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
 import java.util.*;
 
 
@@ -91,17 +89,19 @@ public class YachtVacancyScraper extends VacancyScraper {
         return response.getBody();
     }
 
-    // The getTotalNumberOfPages method is not used by this scraper. As the YachtVacancyScraper extends VacancyScraper it is required to provide an implementation for this method.
+    // getTotalNumberOfPages method is not used by this scraper. As we extend the abstract class VacancyScraper it is required to override this method and provide a return value.
     @Override
     protected int getTotalNumberOfPages(Document doc) {
         return 1;
     }
 
+    // We retrieve the vacancy title in an earlier stage as the title is returned in the get request (scrapeVacancies(int pageNumber) method). Decided to show the title of the vacancy when this method is called. That way it is clear the scraper is doing it's job.
     @Override
     protected void setVacancyTitle(Document doc, Vacancy vacancy) {
         log.info("YACHT -- Scraping: " + vacancy.getTitle());
     }
 
+    // setVacancySpecifics method is not used for this scraper. As we extend the abstract class VacancyScraper it is required to override this method.
     @Override
     protected void setVacancySpecifics(Document doc, Vacancy vacancy) {
     }

--- a/src/main/java/nl/ordina/jobcrawler/service/VacancyStarter.java
+++ b/src/main/java/nl/ordina/jobcrawler/service/VacancyStarter.java
@@ -75,13 +75,7 @@ public class VacancyStarter {
         log.info("CRON Scheduled -- Started deleting non-existing jobs");
         List<Vacancy> allVacancies = vacancyService.getAllVacancies();
         List<Vacancy> vacanciesToDelete = allVacancies.stream()
-                .filter(vacancy -> {
-                    if ("Yacht".equals(vacancy.getBroker())) {
-                        return !yachtVacancyScraper.doesVacancyExist(vacancy.getVacancyURL());
-                    } else {
-                        return !vacancy.hasValidURL();
-                    }
-                }) //if the url is not good anymore add it in the vacanciesToDelete
+                .filter(vacancy -> !vacancy.hasValidURL()) //if the url is not good anymore add it in the vacanciesToDelete
                 .collect(Collectors.toList());
 
         log.info(vacanciesToDelete.size() + " vacancy to delete.");


### PR DESCRIPTION
Yacht scraper fix.
- Removed vacancy returns status 410. Was previously status 200. Can use the same `hasValidURL` method.
- Retrieving the vacancy urls per page via a get request.
- Modified the VacancyURLs class to fill more fields from the response of the get request.