### PR TITLE
added system.properties file

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
in the system.properties the java runtime version is specified (11). Heroku installs this version of the jdk instead of the default version (1.8)